### PR TITLE
Make license file optional

### DIFF
--- a/scripts/bootstrap_package/lib/run_command.dart
+++ b/scripts/bootstrap_package/lib/run_command.dart
@@ -22,6 +22,7 @@ void runCommand(List<String> args) {
           ..addOption('description', abbr: 'd')
           ..addMultiOption('dependencies', abbr: 'p')
           ..addMultiOption('dev_dependencies', abbr: 'v')
+          ..addFlag('license', abbr: 'l')
           ..addFlag('help', abbr: 'h', negatable: false);
     final parsedArgs = parser.parse(args);
 
@@ -76,7 +77,10 @@ void runCommand(List<String> args) {
 
     // LICENSEファイル削除し、プロジェクトルートのものをsymbolic linkで追加
     final licenseFile = File('LICENSE')..deleteSync();
-    Link(licenseFile.path).createSync(path.join('../..', licenseFile.path));
+    final shouldAddLicense = parsedArgs['license'] as bool;
+    if (shouldAddLicense) {
+      Link(licenseFile.path).createSync(path.join('../..', licenseFile.path));
+    }
 
     // READMEファイルをパッケージ名のみに上書き
     final packageTitle = '# $name';

--- a/scripts/bootstrap_package/lib/show_usage.dart
+++ b/scripts/bootstrap_package/lib/show_usage.dart
@@ -18,6 +18,7 @@ Options:
 -d, --description <パッケージ説明>             パッケージの説明を指定
 -p, --dependencies <package1,package2>       作成するパッケージの dependencies へ追加したい外部パッケージを指定
 -v, --dev_dependencies <package1,package2>   作成するパッケージの dev_dependencies へ追加したい外部パッケージを指定
+-l, --license              　　　　　　　　　　　ルートディレクトリのライセンスへのシンボリックリンクを作成
 -h, --help　　　　　　　                        使い方を表示
 
 Example:


### PR DESCRIPTION
Since a private repository doesn't need a license, the project might not have a license in its root.