### PR TITLE
Enable pub add for workspace

### DIFF
--- a/scripts/bootstrap_package/CHANGELOG.md
+++ b/scripts/bootstrap_package/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Enabled adding dependencies for workspace ([#14](https://github.com/masa-tokyo/flutter_toolkit/pull/14))
+
 ## 1.1.0
 
 - Added optional commands to create a Dart or Flutter package ([#11](https://github.com/masa-tokyo/flutter_toolkit/pull/11))

--- a/scripts/bootstrap_package/lib/finalize_setup.dart
+++ b/scripts/bootstrap_package/lib/finalize_setup.dart
@@ -1,15 +1,25 @@
+import 'dart:io';
+
 import 'run_command.dart';
 import 'run_dart.dart';
-import 'run_flutter.dart';
 
 /// [runCommand]の最後に実行する関数
-void finalizeSetup({required PackageType packageType}) {
-  // 生成したシンボリックリンクを同期させる
-  switch (packageType) {
-    case PackageType.dart:
-      runDart(['pub', 'get']);
-    case PackageType.flutter:
-      runFlutter(['pub', 'get']);
+void finalizeSetup({
+  required PackageType packageType,
+  required bool enableWorkspace,
+  required String packageName,
+}) {
+  if (enableWorkspace) {
+    stdout.writeln('''
+Pub Workspace を有効化するために、以下のようにパッケージを追加してください。
+```yaml
+workspace:
+  - packages/$packageName
+```
+その後、`melos bs`コマンドにより、生成したシンボリックリンクやパッケージのバージョンを同期してください。''');
+  } else {
+    // 生成したシンボリックリンクやパッケージのバージョンを同期させる
+    Process.runSync('melos', ['bootstrap']);
   }
 
   // 生成されたパッケージ内のファイルを整形

--- a/scripts/bootstrap_package/lib/overwrite_pubspec_yaml_file.dart
+++ b/scripts/bootstrap_package/lib/overwrite_pubspec_yaml_file.dart
@@ -71,14 +71,16 @@ $flutterBlock
 
   File('pubspec.yaml').writeAsStringSync(content);
 
+  final runCommand = packageType == PackageType.dart ? runDart : runFlutter;
+
   // dependencies を追加
   for (final dependency in dependencies) {
-    runFlutter(['pub', 'add', dependency]);
+    runCommand(['pub', 'add', dependency]);
   }
 
   // devDependencies を追加
   for (final devDependency in devDependencies) {
-    runFlutter(['pub', 'add', '--dev', devDependency]);
+    runCommand(['pub', 'add', '--dev', devDependency]);
   }
 }
 

--- a/scripts/bootstrap_package/lib/overwrite_pubspec_yaml_file.dart
+++ b/scripts/bootstrap_package/lib/overwrite_pubspec_yaml_file.dart
@@ -83,8 +83,6 @@ $flutterBlock
 /// pubspec.yamlに記載するdart sdkのバージョンを取得する関数
 ///
 /// FVMのdart versionを取得し、そのバージョンをキャレット記号にて記述する。
-/// 尚、pubspec.yamlファイル作成後に`melos bs`コマンドを実行しても同様の結果になるが、
-/// コマンドの実行時間削減のためにこのように実装している。
 @visibleForTesting
 String getDartCaretVersion() {
   final versionResult = runDart(['--version']);

--- a/scripts/bootstrap_package/lib/overwrite_pubspec_yaml_file.dart
+++ b/scripts/bootstrap_package/lib/overwrite_pubspec_yaml_file.dart
@@ -30,7 +30,7 @@ void overwritePubspecYamlFile({
 }) {
   final dartVersion = getDartCaretVersion();
   final resolution = enableWorkspace ? 'resolution: workspace\n' : '';
-  final dependenciesBlock = switch (packageType) {
+  final dependencyEntries = switch (packageType) {
     PackageType.dart => '',
     PackageType.flutter => '''
   flutter:
@@ -63,7 +63,7 @@ environment:
   sdk: $dartVersion
 $resolution
 dependencies:
-$dependenciesBlock
+$dependencyEntries
 dev_dependencies:
 $devDependencyEntries
 $flutterBlock

--- a/scripts/bootstrap_package/lib/run_command.dart
+++ b/scripts/bootstrap_package/lib/run_command.dart
@@ -116,7 +116,11 @@ void runCommand(List<String> args) {
     final packageTitle = '# $name';
     File('README.md').writeAsStringSync(packageTitle);
 
-    finalizeSetup(packageType: packageType);
+    finalizeSetup(
+      packageType: packageType,
+      enableWorkspace: enableWorkspace,
+      packageName: name,
+    );
   } on FormatException catch (_) {
     // '-d'のようなoptionコマンドに続く引数が入力されていない場合
     showUsage(errorMessage: 'オプションコマンドの使い方が間違っています。');

--- a/scripts/bootstrap_package/lib/show_usage.dart
+++ b/scripts/bootstrap_package/lib/show_usage.dart
@@ -21,8 +21,8 @@ Options:
 -w, --[no-]workspace　　　　　　　　　　　　　　　Pub Workspace を利用したパッケージを作成
 -l, --[no-]license              　　　　　　　　ルートディレクトリのライセンスへのシンボリックリンクを作成
 
--p, --dependencies <package1,package2>       作成するパッケージの dependencies へ追加したい外部パッケージを指定
--v, --dev_dependencies <package1,package2>   作成するパッケージの dev_dependencies へ追加したい外部パッケージを指定
+-p, --dependencies=<package1,package2>       作成するパッケージの dependencies へ追加したい外部パッケージを指定 (-w が false の場合のみ）
+-v, --dev_dependencies=<package1,package2>   作成するパッケージの dev_dependencies へ追加したい外部パッケージを指定 (-w が false の場合のみ）
     --description <パッケージ説明>             パッケージの説明を指定
 
 Example:

--- a/scripts/bootstrap_package/lib/show_usage.dart
+++ b/scripts/bootstrap_package/lib/show_usage.dart
@@ -21,8 +21,8 @@ Options:
 -w, --[no-]workspace　　　　　　　　　　　　　　　Pub Workspace を利用したパッケージを作成
 -l, --[no-]license              　　　　　　　　ルートディレクトリのライセンスへのシンボリックリンクを作成
 
--p, --dependencies=<package1,package2>       作成するパッケージの dependencies へ追加したい外部パッケージを指定 (-w が false の場合のみ）
--v, --dev_dependencies=<package1,package2>   作成するパッケージの dev_dependencies へ追加したい外部パッケージを指定 (-w が false の場合のみ）
+-p, --dependencies=<package1,package2>       作成するパッケージの dependencies へ追加したい外部パッケージを指定
+-v, --dev_dependencies=<package1,package2>   作成するパッケージの dev_dependencies へ追加したい外部パッケージを指定
     --description <パッケージ説明>             パッケージの説明を指定
 
 Example:

--- a/scripts/bootstrap_package/pubspec.yaml
+++ b/scripts/bootstrap_package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bootstrap_package
 description: A command-line application to bootstrap formatted Flutter packages.
-version: 1.1.0
+version: 1.1.1
 
 environment:
   sdk: ^3.7.0

--- a/scripts/bootstrap_package/pubspec.yaml
+++ b/scripts/bootstrap_package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bootstrap_package
 description: A command-line application to bootstrap formatted Flutter packages.
-version: 1.1.1
+version: 1.1.2
 
 environment:
   sdk: ^3.7.0


### PR DESCRIPTION
In workspace projects, you cannot run `flutter pub add <dependency>` or `melos bs` command until you actually add the package to the workspace field on the pubspec.yaml in the root directory. So, packages passed via `dependencies` and `dev_dependencies` commands are now manually written on the `pubspec.yaml` file.